### PR TITLE
Exception if product doesn't have an image

### DIFF
--- a/app/code/community/Receiptful/Core/Observer/Receipt.php
+++ b/app/code/community/Receiptful/Core/Observer/Receipt.php
@@ -305,12 +305,19 @@ class Receiptful_Core_Observer_Receipt
                 $similarProduct = $productModel
                     ->load($similarProduct->getId());
 
-                $data['upsell']['products'][] = array(
+                $similarProductData = array(
                     'title' => $similarProduct->getName(),
                     'description' => $similarProduct->getShortDescription(),
-                    'image' => (string) Mage::helper('catalog/image')->init($product, 'thumbnail'),
                     'actionUrl' => $similarProduct->getProductUrl()
                 );
+
+                try {
+                    $similarProductData['image'] = (string) Mage::helper('catalog/image')->init($product, 'thumbnail');
+                } catch (Exception $e) {
+                    // Unable to load the image, skip it.
+                }
+
+                $data['upsell']['products'][] = $similarProductData;
             }
 
             break;


### PR DESCRIPTION
Ref: https://www.magentocommerce.com/magento-connect/message/message/view/message/332429/

Hello,
I found an error in extension Receipt.php observer class. It occurs if product doesn't have thumbnail image set.

exception 'Exception' with message 'Image file was not found.' in .../app/code/core/Mage/Catalog/Model/Product/Image.php:308 
Stack trace: 
#0 .../app/code/core/Mage/Catalog/Helper/Image.php(166): Mage_Catalog_Model_Product_Image->setBaseFile('no_selection') 
#1 .../app/code/community/Receiptful/Core/Observer/Receipt.php(311): Mage_Catalog_Helper_Image->init(Object(Mage_Catalog_Model_Product), 'thumbnail') 
#2 .../app/code/community/Receiptful/Core/Observer/Receipt.php(38): Receiptful_Core_Observer_Receipt->transformInvoiceToReceipt(Object(Mage_Sales_Model_Order_Invoice)) #3 .../app/code/community/Receiptful/Core/Observer/Receipt.php(25): Receiptful_Core_Observer_Receipt->createInvoiceReceipt(Object(Mage_Sales_Model_Order_Invoice)) 
#4 .../app/code/core/Mage/Core/Model/App.php(1338): Receiptful_Core_Observer_Receipt->createReceipt(Object(Varien_Event_Observer))

Best regards,
Lasse H 